### PR TITLE
Update vite to 7.3.6 in the example app

### DIFF
--- a/examples/tauri-app/package.json
+++ b/examples/tauri-app/package.json
@@ -27,7 +27,7 @@
     "svelte": "^5.56.10",
     "ts-node": "^10.9.2",
     "typescript": "^7.0.2",
-    "vite": "^7.0.0",
+    "vite": "^7.3.6",
     "webdriverio": "^9.31.2"
   },
   "packageManager": "pnpm@10.16.0+sha512.8066e7b034217b700a9a4dbb3a005061d641ba130a89915213a10b3ca4919c19c037bec8066afdc559b89635fdb806b16ea673f2468fbb28aabfa13c53e3f769"

--- a/examples/tauri-app/pnpm-lock.yaml
+++ b/examples/tauri-app/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
-        version: 6.2.4(svelte@5.56.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))
+        version: 6.2.4(svelte@5.56.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))
       '@tauri-apps/cli':
         specifier: ^2.11.4
         version: 2.11.4
@@ -49,8 +49,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vite:
-        specifier: ^7.0.0
-        version: 7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)
+        specifier: ^7.3.6
+        version: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)
       webdriverio:
         specifier: ^9.31.2
         version: 9.31.2
@@ -2463,8 +2463,8 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3119,22 +3119,22 @@ snapshots:
     dependencies:
       acorn: 8.18.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)))(svelte@5.56.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)))(svelte@5.56.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))
       obug: 2.1.1
       svelte: 5.56.10
-      vite: 7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)
+      vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)))(svelte@5.56.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)))(svelte@5.56.10)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.56.10
-      vite: 7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))
+      vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)
+      vitefu: 1.1.1(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12))
 
   '@tauri-apps/api@2.11.1': {}
 
@@ -5051,7 +5051,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12):
+  vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.7)
@@ -5065,9 +5065,9 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.12
 
-  vitefu@1.1.1(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)):
+  vitefu@1.1.1(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)
+      vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)
 
   wait-port@1.1.0:
     dependencies:


### PR DESCRIPTION
Bump vite in the example app from the 7.3.1 the lockfile resolved to 7.3.6, and raise the range floor to match. 7.3.2 fixed several security issues in the vite dev server, so this clears the open vite advisories against `examples/tauri-app/pnpm-lock.yaml`. Dev-dependency of the example app only — nothing shipped changes.