### PR TITLE
Publish installs glib headers via the shared apt setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,11 +25,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Cache and install APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: Choochmeque/reusable-actions/actions/setup-linux-deps@v1
         with:
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-          version: "1.0"
+          packages: libglib2.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       # Toolchain
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
`cargo publish` builds `glib-sys`, which needs the glib headers; the publish workflow's apt list lacked `libglib2.0-dev` and never refreshed the index (the class sharekit fixed in #245). The step moves to the shared `setup-linux-deps` composite with the package added.