### PR TITLE
Scope push CI to main

### DIFF
--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -3,7 +3,11 @@ name: Build Demo
 on:
   pull_request:
   push:
-    branches: ['**']
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Build the example app on every desktop OS. Catches platform-specific

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,13 +1,17 @@
 name: Checks
 
-on: [ pull_request, push, workflow_dispatch ]
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Code formatting.


### PR DESCRIPTION
Push-triggered CI now runs on main only (tags and topic branches no longer duplicate the PR runs), and main runs get a unique concurrency group so they cannot be cancelled by a following push.